### PR TITLE
Add Terrainer plugin hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,18 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.github.chrisrnj.Terrainer</groupId>
+      <artifactId>terrainer-core</artifactId>
+      <version>9ab2f53d41</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <!-- Tests -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/github/jikoo/regionerator/hooks/TerrainerHook.java
+++ b/src/main/java/com/github/jikoo/regionerator/hooks/TerrainerHook.java
@@ -1,0 +1,31 @@
+package com.github.jikoo.regionerator.hooks;
+
+import com.epicnicity322.terrainer.core.terrain.Terrain;
+import com.epicnicity322.terrainer.core.terrain.TerrainManager;
+import com.epicnicity322.terrainer.core.terrain.WorldTerrain;
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * PluginHook for <a href="https://github.com/chrisrnj/Terrainer">Terrainer</a>.
+ */
+public class TerrainerHook extends PluginHook {
+
+    public TerrainerHook() {
+        super("Terrainer");
+    }
+
+    @Override
+    public boolean isChunkProtected(@NotNull World chunkWorld, int chunkX, int chunkZ) {
+        for (Terrain terrain : TerrainManager.terrainsAtChunk(chunkWorld.getUID(), chunkX, chunkZ)) {
+            if (!(terrain instanceof WorldTerrain)) return true; // Global world terrain is ignored.
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncCapable() {
+        return true;
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -88,6 +88,7 @@ hooks:
   PreciousStones: true
   RedProtect: true
   Residence: true
+  Terrainer: true
   Towny: true
   WorldGuard: true
   VanillaSpawnProtection: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,6 +16,7 @@ softdepend:
 - Multiverse-Core
 - RedProtect
 - Residence
+- Terrainer
 - Towny
 - WorldGuard
 


### PR DESCRIPTION
Terrainer is a work in progress region claiming protection plugin.
There's global terrains and player terrains, this PR adds a check whether a chunk contains a player's terrain.

Terrainer does not have a release yet, but it can be compiled from its [repository](https://github.com/chrisrnj/Terrainer) and used. Someone has requested me to add compatibility with this plugin.