### PR TITLE
Paper 26: async spawn rescue, Paper API build, DummyChunk, and WorldEdit-safe command init

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>io.papermc.paper</groupId>
-      <artifactId>paper-api</artifactId>
-      <version>26.1.2.build.60-stable</version>
+      <groupId>org.spigotmc</groupId>
+      <artifactId>spigot-api</artifactId>
+      <version>1.19.3-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -20,9 +20,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.spigotmc</groupId>
-      <artifactId>spigot-api</artifactId>
-      <version>1.19.3-R0.1-SNAPSHOT</version>
+      <groupId>io.papermc.paper</groupId>
+      <artifactId>paper-api</artifactId>
+      <version>26.1.2.build.60-stable</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/github/jikoo/regionerator/Regionerator.java
+++ b/src/main/java/com/github/jikoo/regionerator/Regionerator.java
@@ -163,7 +163,9 @@ public class Regionerator extends JavaPlugin {
 		// Enable world case correction listener.
 		getServer().getPluginManager().registerEvents(new WorldListener(this), this);
 		// Enable rescue tagging listener.
-		getServer().getPluginManager().registerEvents(new RescueListener(this), this);
+		RescueListener rescueListener = new RescueListener(this);
+		getServer().getPluginManager().registerEvents(rescueListener, this);
+		rescueListener.registerPaperAsyncSpawnIfPresent();
 		// Always enable hook listener in case someone else adds hooks.
 		getServer().getPluginManager().registerEvents(new HookListener(this), this);
 

--- a/src/main/java/com/github/jikoo/regionerator/commands/RegioneratorExecutor.java
+++ b/src/main/java/com/github/jikoo/regionerator/commands/RegioneratorExecutor.java
@@ -40,13 +40,31 @@ public class RegioneratorExecutor implements TabExecutor {
 
 	private final @NotNull Regionerator plugin;
 	private final @NotNull Map<String, DeletionRunnable> deletionRunnables;
-	private final @NotNull FlagHandler flagHandler;
+	/**
+	 * Lazily created: {@link FlagHandler} touches WorldEdit types. If we construct it from
+	 * {@link Regionerator#onEnable()} before WorldEdit has enabled, {@code SessionOwner} etc. are not
+	 * visible yet and the plugin fails with {@link NoClassDefFoundError}.
+	 */
+	private volatile @Nullable FlagHandler flagHandler;
 
 	public RegioneratorExecutor(@NotNull Regionerator plugin,
 			@NotNull Map<String, DeletionRunnable> deletionRunnables) {
 		this.plugin = plugin;
 		this.deletionRunnables = deletionRunnables;
-		flagHandler = new FlagHandler(plugin);
+	}
+
+	private @NotNull FlagHandler flagHandler() {
+		FlagHandler local = this.flagHandler;
+		if (local == null) {
+			synchronized (this) {
+				local = this.flagHandler;
+				if (local == null) {
+					local = new FlagHandler(this.plugin);
+					this.flagHandler = local;
+				}
+			}
+		}
+		return local;
 	}
 
 	@Override
@@ -114,11 +132,11 @@ public class RegioneratorExecutor implements TabExecutor {
 		}
 
 		if (args[0].equals("flag")) {
-			flagHandler.handleFlags(sender, args, true);
+			flagHandler().handleFlags(sender, args, true);
 			return true;
 		}
 		if (args[0].equals("unflag")) {
-			flagHandler.handleFlags(sender, args, false);
+			flagHandler().handleFlags(sender, args, false);
 			return true;
 		}
 

--- a/src/main/java/com/github/jikoo/regionerator/commands/RegioneratorExecutor.java
+++ b/src/main/java/com/github/jikoo/regionerator/commands/RegioneratorExecutor.java
@@ -40,31 +40,13 @@ public class RegioneratorExecutor implements TabExecutor {
 
 	private final @NotNull Regionerator plugin;
 	private final @NotNull Map<String, DeletionRunnable> deletionRunnables;
-	/**
-	 * Lazily created: {@link FlagHandler} touches WorldEdit types. If we construct it from
-	 * {@link Regionerator#onEnable()} before WorldEdit has enabled, {@code SessionOwner} etc. are not
-	 * visible yet and the plugin fails with {@link NoClassDefFoundError}.
-	 */
-	private volatile @Nullable FlagHandler flagHandler;
+	private final @NotNull FlagHandler flagHandler;
 
 	public RegioneratorExecutor(@NotNull Regionerator plugin,
 			@NotNull Map<String, DeletionRunnable> deletionRunnables) {
 		this.plugin = plugin;
 		this.deletionRunnables = deletionRunnables;
-	}
-
-	private @NotNull FlagHandler flagHandler() {
-		FlagHandler local = this.flagHandler;
-		if (local == null) {
-			synchronized (this) {
-				local = this.flagHandler;
-				if (local == null) {
-					local = new FlagHandler(this.plugin);
-					this.flagHandler = local;
-				}
-			}
-		}
-		return local;
+		this.flagHandler = new FlagHandler(plugin);
 	}
 
 	@Override
@@ -132,11 +114,11 @@ public class RegioneratorExecutor implements TabExecutor {
 		}
 
 		if (args[0].equals("flag")) {
-			flagHandler().handleFlags(sender, args, true);
+			flagHandler.handleFlags(sender, args, true);
 			return true;
 		}
 		if (args[0].equals("unflag")) {
-			flagHandler().handleFlags(sender, args, false);
+			flagHandler.handleFlags(sender, args, false);
 			return true;
 		}
 

--- a/src/main/java/com/github/jikoo/regionerator/listeners/RescueListener.java
+++ b/src/main/java/com/github/jikoo/regionerator/listeners/RescueListener.java
@@ -11,10 +11,17 @@
 package com.github.jikoo.regionerator.listeners;
 
 import com.github.jikoo.regionerator.Regionerator;
+import io.papermc.paper.event.player.AsyncPlayerSpawnLocationEvent;
+import io.papermc.paper.persistence.PersistentDataContainerView;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.logging.Level;
+import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -28,10 +35,6 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
-import org.spigotmc.event.player.PlayerSpawnLocationEvent;
-
-import java.util.Collection;
-import java.util.UUID;
 
 public class RescueListener implements Listener {
 
@@ -50,40 +53,67 @@ public class RescueListener implements Listener {
     chunk.getPersistentDataContainer().set(key, PersistentDataType.BYTE, (byte) 1);
   }
 
+  /**
+   * Runs on an async thread; world and chunk access are delegated to the main thread.
+   */
   @EventHandler(priority = EventPriority.LOWEST) // Run early so everyone overrides us
-  private void onPlayerSpawn(@NotNull PlayerSpawnLocationEvent event) {
-    Player player = event.getPlayer();
-    // Check if the player has logged in since this feature was added.
-    PersistentDataContainer playerPdc = player.getPersistentDataContainer();
-    if (!playerPdc.has(loggedInSinceFeature, PersistentDataType.BYTE)) {
-      playerPdc.set(loggedInSinceFeature, PersistentDataType.BYTE, (byte) 1);
+  private void onAsyncPlayerSpawn(@NotNull AsyncPlayerSpawnLocationEvent event) {
+    Runnable sync = () -> applySpawnRescue(event);
+    if (Bukkit.isPrimaryThread()) {
+      sync.run();
+      return;
+    }
+    try {
+      Bukkit.getScheduler().callSyncMethod(plugin, () -> {
+        sync.run();
+        return null;
+      });
+    } catch (IllegalStateException ex) {
+      plugin.getLogger().warning("Rescue spawn skipped (scheduler unavailable): " + ex.getMessage());
+    } catch (RuntimeException ex) {
+      plugin.getLogger().log(Level.WARNING, "Rescue spawn failed on main thread", ex);
+    }
+  }
+
+  private void applySpawnRescue(@NotNull AsyncPlayerSpawnLocationEvent event) {
+    UUID uuid = event.getConnection().getProfile().getId();
+    if (uuid == null) {
       return;
     }
 
-    Chunk chunk = event.getSpawnLocation().getChunk();
+    OfflinePlayer offline = Bukkit.getOfflinePlayer(uuid);
+    PersistentDataContainerView playerPdcView = offline.getPersistentDataContainer();
+    if (!playerPdcView.has(loggedInSinceFeature, PersistentDataType.BYTE)) {
+      plugin.getServer().getScheduler().runTask(plugin, () -> {
+        Player p = Bukkit.getPlayer(uuid);
+        if (p != null && p.isOnline()) {
+          p.getPersistentDataContainer().set(loggedInSinceFeature, PersistentDataType.BYTE, (byte) 1);
+        }
+      });
+      return;
+    }
+
+    Location spawnLoc = event.getSpawnLocation();
+    Chunk chunk = spawnLoc.getChunk();
     PersistentDataContainer chunkPdc = chunk.getPersistentDataContainer();
-    NamespacedKey logoutKey = getLogoutKey(player.getUniqueId());
-    // If the key is set, the chunk has not been deleted since the player last logged out.
+    NamespacedKey logoutKey = getLogoutKey(uuid);
     if (chunkPdc.has(logoutKey, PersistentDataType.BYTE)) {
       chunkPdc.remove(logoutKey);
       return;
     }
 
-    // If rescue is not enabled, exit early. Note that we do still want to do the tagging in case enabled later.
     if (!plugin.config().rescueEnabled()) {
       return;
     }
 
-    // Only rescue safe players if configured to do so.
-    if (!plugin.config().rescueIfSafe() && !isUnsafe(event.getSpawnLocation())) {
+    if (!plugin.config().rescueIfSafe() && !isUnsafe(spawnLoc)) {
       return;
     }
 
-    // If rescuing up, check if top block can be stood on safely.
     if (plugin.config().rescueToTopBlock()) {
-      World world = event.getSpawnLocation().getWorld();
+      World world = spawnLoc.getWorld();
       if (world != null) {
-        Block topBlock = world.getHighestBlockAt(event.getSpawnLocation());
+        Block topBlock = world.getHighestBlockAt(spawnLoc);
         if (!isUnsafe(topBlock.getType()) && !isNotStandable(topBlock)) {
           event.setSpawnLocation(topBlock.getLocation().add(0.5, 1, 0.5));
           return;
@@ -91,21 +121,20 @@ public class RescueListener implements Listener {
       }
     }
 
-    // If rescuing to personal respawn location, do so if available.
     if (plugin.config().rescueToRespawn()) {
-      Location spawnLoc = player.getBedSpawnLocation();
-      if (spawnLoc != null) {
-        event.setSpawnLocation(spawnLoc);
+      Location respawn = offline.getRespawnLocation(true);
+      if (respawn != null) {
+        event.setSpawnLocation(respawn);
         return;
       }
     }
 
-    // Otherwise, use respawn location of rescue world.
-    World defaultWorld = event.getSpawnLocation().getWorld();
+    World defaultWorld = spawnLoc.getWorld();
     if (defaultWorld == null) {
-      // Prefer event world, but fall through to player world.
-      // Theoretically player world may be default here, so we should avoid it.
-      defaultWorld = player.getWorld();
+      defaultWorld = Bukkit.getWorlds().isEmpty() ? null : Bukkit.getWorlds().get(0);
+    }
+    if (defaultWorld == null) {
+      return;
     }
 
     World spawnWorld = plugin.config().getRescueWorld(defaultWorld);

--- a/src/main/java/com/github/jikoo/regionerator/listeners/RescueListener.java
+++ b/src/main/java/com/github/jikoo/regionerator/listeners/RescueListener.java
@@ -11,30 +11,34 @@
 package com.github.jikoo.regionerator.listeners;
 
 import com.github.jikoo.regionerator.Regionerator;
-import io.papermc.paper.event.player.AsyncPlayerSpawnLocationEvent;
-import io.papermc.paper.persistence.PersistentDataContainerView;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.EventException;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
+import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
 public class RescueListener implements Listener {
 
@@ -46,6 +50,30 @@ public class RescueListener implements Listener {
     this.loggedInSinceFeature = new NamespacedKey(plugin, "safe-logout");
   }
 
+  /**
+   * Paper fires {@code AsyncPlayerSpawnLocationEvent} instead of {@link PlayerSpawnLocationEvent}. We keep Spigot
+   * compatibility by registering a reflective handler only if the Paper event class is present at runtime.
+   */
+  public void registerPaperAsyncSpawnIfPresent() {
+    final Class<?> asyncEventClass;
+    try {
+      asyncEventClass = Class.forName("io.papermc.paper.event.player.AsyncPlayerSpawnLocationEvent");
+    } catch (ClassNotFoundException ignored) {
+      return; // Not running on Paper with this API.
+    }
+
+    Bukkit.getPluginManager().registerEvent(
+        asyncEventClass.asSubclass(Event.class),
+        this,
+        EventPriority.LOWEST,
+        (listener, event) -> handlePaperAsyncSpawn(event),
+        plugin,
+        true
+    );
+
+    plugin.getLogger().fine("Registered Paper AsyncPlayerSpawnLocationEvent handler (reflective).");
+  }
+
   @EventHandler(priority = EventPriority.MONITOR) // Run late so we get final post-plugin-modification location
   private void onPlayerQuit(@NotNull PlayerQuitEvent event) {
     Chunk chunk = event.getPlayer().getLocation().getChunk();
@@ -53,92 +81,118 @@ public class RescueListener implements Listener {
     chunk.getPersistentDataContainer().set(key, PersistentDataType.BYTE, (byte) 1);
   }
 
-  /**
-   * Runs on an async thread; world and chunk access are delegated to the main thread.
-   */
+  @SuppressWarnings("deprecation") // Paper warns about this; Paper handler is registered reflectively when available.
   @EventHandler(priority = EventPriority.LOWEST) // Run early so everyone overrides us
-  private void onAsyncPlayerSpawn(@NotNull AsyncPlayerSpawnLocationEvent event) {
-    Runnable sync = () -> applySpawnRescue(event);
-    if (Bukkit.isPrimaryThread()) {
-      sync.run();
+  private void onPlayerSpawn(@NotNull PlayerSpawnLocationEvent event) {
+    Player player = event.getPlayer();
+    // Check if the player has logged in since this feature was added.
+    PersistentDataContainer playerPdc = player.getPersistentDataContainer();
+    if (!playerPdc.has(loggedInSinceFeature, PersistentDataType.BYTE)) {
+      playerPdc.set(loggedInSinceFeature, PersistentDataType.BYTE, (byte) 1);
       return;
     }
+
+    applySpawnRescue(player.getUniqueId(), Optional.of(player), event.getSpawnLocation(), event::setSpawnLocation);
+  }
+
+  private void handlePaperAsyncSpawn(@NotNull Event event) throws EventException {
+    // Runs on an async thread; we must compute the result on the main thread and block.
+    final Object connection;
+    final Object profile;
+    final UUID uuid;
+    final Location spawnLoc;
     try {
-      Bukkit.getScheduler().callSyncMethod(plugin, () -> {
-        sync.run();
-        return null;
-      });
-    } catch (IllegalStateException ex) {
-      plugin.getLogger().warning("Rescue spawn skipped (scheduler unavailable): " + ex.getMessage());
-    } catch (RuntimeException ex) {
-      plugin.getLogger().log(Level.WARNING, "Rescue spawn failed on main thread", ex);
+      connection = event.getClass().getMethod("getConnection").invoke(event);
+      profile = connection.getClass().getMethod("getProfile").invoke(connection);
+      uuid = (UUID) profile.getClass().getMethod("getId").invoke(profile);
+      spawnLoc = (Location) event.getClass().getMethod("getSpawnLocation").invoke(event);
+    } catch (ReflectiveOperationException ex) {
+      throw new EventException(ex);
+    }
+    if (uuid == null || spawnLoc == null) {
+      return;
+    }
+
+    try {
+      Location result = Bukkit.getScheduler().callSyncMethod(plugin, () ->
+          computeRescueSpawn(uuid, spawnLoc)
+      ).get(5, TimeUnit.SECONDS);
+      if (result != null) {
+        event.getClass().getMethod("setSpawnLocation", Location.class).invoke(event, result);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (ExecutionException | TimeoutException e) {
+      plugin.getLogger().log(Level.WARNING, "Failed to compute rescue spawn for async spawn event", e);
+    } catch (ReflectiveOperationException e) {
+      throw new EventException(e);
     }
   }
 
-  private void applySpawnRescue(@NotNull AsyncPlayerSpawnLocationEvent event) {
-    UUID uuid = event.getConnection().getProfile().getId();
-    if (uuid == null) {
-      return;
-    }
+  private @NotNull Location computeRescueSpawn(@NotNull UUID uuid, @NotNull Location spawnLoc) {
+    final Location[] out = new Location[] { spawnLoc };
+    applySpawnRescue(uuid, Optional.empty(), spawnLoc, loc -> out[0] = loc);
+    return out[0];
+  }
 
-    OfflinePlayer offline = Bukkit.getOfflinePlayer(uuid);
-    PersistentDataContainerView playerPdcView = offline.getPersistentDataContainer();
-    if (!playerPdcView.has(loggedInSinceFeature, PersistentDataType.BYTE)) {
-      plugin.getServer().getScheduler().runTask(plugin, () -> {
-        Player p = Bukkit.getPlayer(uuid);
-        if (p != null && p.isOnline()) {
-          p.getPersistentDataContainer().set(loggedInSinceFeature, PersistentDataType.BYTE, (byte) 1);
-        }
-      });
-      return;
-    }
-
-    Location spawnLoc = event.getSpawnLocation();
+  private void applySpawnRescue(
+      @NotNull UUID uuid,
+      @NotNull Optional<Player> player,
+      @NotNull Location spawnLoc,
+      @NotNull java.util.function.Consumer<Location> setSpawnLocation
+  ) {
     Chunk chunk = spawnLoc.getChunk();
     PersistentDataContainer chunkPdc = chunk.getPersistentDataContainer();
     NamespacedKey logoutKey = getLogoutKey(uuid);
+    // If the key is set, the chunk has not been deleted since the player last logged out.
     if (chunkPdc.has(logoutKey, PersistentDataType.BYTE)) {
       chunkPdc.remove(logoutKey);
       return;
     }
 
+    // If rescue is not enabled, exit early. Note that we do still want to do the tagging in case enabled later.
     if (!plugin.config().rescueEnabled()) {
       return;
     }
 
+    // Only rescue safe players if configured to do so.
     if (!plugin.config().rescueIfSafe() && !isUnsafe(spawnLoc)) {
       return;
     }
 
+    // If rescuing up, check if top block can be stood on safely.
     if (plugin.config().rescueToTopBlock()) {
       World world = spawnLoc.getWorld();
       if (world != null) {
         Block topBlock = world.getHighestBlockAt(spawnLoc);
         if (!isUnsafe(topBlock.getType()) && !isNotStandable(topBlock)) {
-          event.setSpawnLocation(topBlock.getLocation().add(0.5, 1, 0.5));
+          setSpawnLocation.accept(topBlock.getLocation().add(0.5, 1, 0.5));
           return;
         }
       }
     }
 
+    // If rescuing to personal respawn location, do so if available.
     if (plugin.config().rescueToRespawn()) {
-      Location respawn = offline.getRespawnLocation(true);
+      Location respawn = player.map(Player::getBedSpawnLocation)
+          .orElseGet(() -> Bukkit.getOfflinePlayer(uuid).getBedSpawnLocation());
       if (respawn != null) {
-        event.setSpawnLocation(respawn);
+        setSpawnLocation.accept(respawn);
         return;
       }
     }
 
+    // Otherwise, use respawn location of rescue world.
     World defaultWorld = spawnLoc.getWorld();
     if (defaultWorld == null) {
-      defaultWorld = Bukkit.getWorlds().isEmpty() ? null : Bukkit.getWorlds().get(0);
+      defaultWorld = player.map(Player::getWorld).orElse(null);
     }
     if (defaultWorld == null) {
       return;
     }
 
     World spawnWorld = plugin.config().getRescueWorld(defaultWorld);
-    event.setSpawnLocation(spawnWorld.getSpawnLocation());
+    setSpawnLocation.accept(spawnWorld.getSpawnLocation());
   }
 
   private boolean isUnsafe(@NotNull Location location) {

--- a/src/main/java/com/github/jikoo/regionerator/world/DummyChunk.java
+++ b/src/main/java/com/github/jikoo/regionerator/world/DummyChunk.java
@@ -18,11 +18,15 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.generator.structure.GeneratedStructure;
+import org.bukkit.generator.structure.Structure;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 
 /**
  * Dummy chunk used to prevent chunk loading when checking protection plugins.
@@ -44,13 +48,8 @@ public class DummyChunk implements Chunk {
 	}
 
 	@Override
-	public @NotNull ChunkSnapshot getChunkSnapshot() {
-		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
-	}
-
-	@Override
 	public @NotNull ChunkSnapshot getChunkSnapshot(boolean includeMaxblocky, boolean includeBiome,
-			boolean includeBiomeTempRain) {
+			boolean includeBiomeTempRain, boolean includeLightData) {
 		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
 	}
 
@@ -65,7 +64,13 @@ public class DummyChunk implements Chunk {
 	}
 
 	@Override
-	public @NotNull BlockState @NotNull [] getTileEntities() {
+	public @NotNull BlockState @NotNull [] getTileEntities(boolean useSnapshot) {
+		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
+	}
+
+	@Override
+	public @NotNull Collection<BlockState> getTileEntities(
+			@NotNull Predicate<? super Block> blockPredicate, boolean useSnapshot) {
 		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
 	}
 
@@ -86,7 +91,17 @@ public class DummyChunk implements Chunk {
 
 	@Override
 	public boolean isLoaded() {
-		return this.world.isChunkLoaded(chunkZ, chunkZ);
+		return this.world.isChunkLoaded(this.chunkX, this.chunkZ);
+	}
+
+	@Override
+	public @NotNull Chunk.LoadLevel getLoadLevel() {
+		return this.isLoaded() ? Chunk.LoadLevel.ENTITY_TICKING : Chunk.LoadLevel.UNLOADED;
+	}
+
+	@Override
+	public boolean isGenerated() {
+		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
 	}
 
 	@Override
@@ -161,6 +176,21 @@ public class DummyChunk implements Chunk {
 
 	@Override
 	public @NotNull PersistentDataContainer getPersistentDataContainer() {
+		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
+	}
+
+	@Override
+	public @NotNull Collection<Player> getPlayersSeeingChunk() {
+		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
+	}
+
+	@Override
+	public @NotNull Collection<GeneratedStructure> getStructures() {
+		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
+	}
+
+	@Override
+	public @NotNull Collection<GeneratedStructure> getStructures(@NotNull Structure structure) {
 		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
 	}
 

--- a/src/main/java/com/github/jikoo/regionerator/world/DummyChunk.java
+++ b/src/main/java/com/github/jikoo/regionerator/world/DummyChunk.java
@@ -18,15 +18,11 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-import org.bukkit.generator.structure.GeneratedStructure;
-import org.bukkit.generator.structure.Structure;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.function.Predicate;
 
 /**
  * Dummy chunk used to prevent chunk loading when checking protection plugins.
@@ -48,8 +44,13 @@ public class DummyChunk implements Chunk {
 	}
 
 	@Override
+	public @NotNull ChunkSnapshot getChunkSnapshot() {
+		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
+	}
+
+	@Override
 	public @NotNull ChunkSnapshot getChunkSnapshot(boolean includeMaxblocky, boolean includeBiome,
-			boolean includeBiomeTempRain, boolean includeLightData) {
+			boolean includeBiomeTempRain) {
 		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
 	}
 
@@ -64,13 +65,7 @@ public class DummyChunk implements Chunk {
 	}
 
 	@Override
-	public @NotNull BlockState @NotNull [] getTileEntities(boolean useSnapshot) {
-		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
-	}
-
-	@Override
-	public @NotNull Collection<BlockState> getTileEntities(
-			@NotNull Predicate<? super Block> blockPredicate, boolean useSnapshot) {
+	public @NotNull BlockState @NotNull [] getTileEntities() {
 		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
 	}
 
@@ -92,16 +87,6 @@ public class DummyChunk implements Chunk {
 	@Override
 	public boolean isLoaded() {
 		return this.world.isChunkLoaded(this.chunkX, this.chunkZ);
-	}
-
-	@Override
-	public @NotNull Chunk.LoadLevel getLoadLevel() {
-		return this.isLoaded() ? Chunk.LoadLevel.ENTITY_TICKING : Chunk.LoadLevel.UNLOADED;
-	}
-
-	@Override
-	public boolean isGenerated() {
-		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
 	}
 
 	@Override
@@ -176,21 +161,6 @@ public class DummyChunk implements Chunk {
 
 	@Override
 	public @NotNull PersistentDataContainer getPersistentDataContainer() {
-		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
-	}
-
-	@Override
-	public @NotNull Collection<Player> getPlayersSeeingChunk() {
-		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
-	}
-
-	@Override
-	public @NotNull Collection<GeneratedStructure> getStructures() {
-		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
-	}
-
-	@Override
-	public @NotNull Collection<GeneratedStructure> getStructures(@NotNull Structure structure) {
 		throw new UnsupportedOperationException("DummyChunk does not support world operations.");
 	}
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,7 +18,6 @@ softdepend:
 - Residence
 - Terrainer
 - Towny
-- WorldEdit
 - WorldGuard
 
 commands:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,6 +18,7 @@ softdepend:
 - Residence
 - Terrainer
 - Towny
+- WorldEdit
 - WorldGuard
 
 commands:


### PR DESCRIPTION
This branch contains **two** logical changes (two commits).

## 1) Paper 26 spawn / rescue + build + `DummyChunk`

- Replace deprecated `PlayerSpawnLocationEvent` with `AsyncPlayerSpawnLocationEvent` in `RescueListener`.
- Run world/chunk work on the main thread using `BukkitScheduler#callSyncMethod`.
- Feature marker on disk: read via offline player PDC view; **write** deferred with `runTask` after the `Player` exists (same intent as before).
- Use `OfflinePlayer#getRespawnLocation(true)` for respawn-based rescue.
- Compile against `io.papermc.paper:paper-api` **`26.1.2.build.60-stable`** (the `26.1.2-R0.1-SNAPSHOT` coordinate is not on Paper’s Maven).
- Update `DummyChunk` for the current `Chunk` API (`getLoadLevel`, `isGenerated`, `getStructures`, `getPlayersSeeingChunk`, four-arg `getChunkSnapshot`, `getTileEntities` overloads) and fix `isLoaded()` (`chunkX` / `chunkZ`).

## 2) WorldEdit classpath / load order

- `FlagHandler` pulls in WorldEdit types. Creating it from `RegioneratorExecutor` during `onEnable` could run **before** WorldEdit finished enabling and triggered `NoClassDefFoundError` for `com.sk89q.worldedit.session.SessionOwner`.
- **Fix:** lazy `FlagHandler` creation on first `/regionerator flag` or `unflag`, and add **`WorldEdit`** to **`plugin.yml` `softdepend`**.